### PR TITLE
Add protection to injection info list and kernel APC queue

### DIFF
--- a/src/injlib/injlib.c
+++ b/src/injlib/injlib.c
@@ -597,7 +597,7 @@ InjpQueueApc(
 
 
   //
-  // Aquire rundown protection before inserting new 
+  // Acquire rundown protection before inserting new 
   // KernelMode APC and release it after injecting
   //
 

--- a/src/injlib/injlib.c
+++ b/src/injlib/injlib.c
@@ -602,8 +602,8 @@ InjpQueueApc(
   //
 
   if (ApcMode == KernelMode) {
-    BOOLEAN aquired = ExAcquireRundownProtection(&ApcRundownProtection);
-    if (!aquired) {
+    BOOLEAN acquired = ExAcquireRundownProtection(&ApcRundownProtection);
+    if (!acquired) {
       ExFreePoolWithTag(Apc, INJ_MEMORY_TAG);
       return STATUS_UNSUCCESSFUL;
     }


### PR DESCRIPTION
Fixes the issues raise at #13

I've created a `FAST_MUTEX` and lock it while interacting with `InjInfoListHead` and `ApcRundownProtection` which acquired before inserting new Kernel APC to the queue and released after it finished.